### PR TITLE
added option trading

### DIFF
--- a/InvestopediaApi/ita.py
+++ b/InvestopediaApi/ita.py
@@ -25,10 +25,15 @@ class Duration(Enum):
 class Account:
     BASE_URL = 'http://www.investopedia.com'
 
-    def __init__(self, email, password,competition_number):
+    def __init__(self, email, password, competition_number=0):
         """
         Logs a user into Investopedia's trading simulator,
-        given a *username* and *password*.
+        and chooses a competition
+        given a *username*, *password*, and *competition_number*
+
+        *competition_number* is the position of the desired game
+        in the dropdown box on http://www.investopedia.com/simulator/home.aspx
+        starting at 0. Default = 0
         """
 
         self.br = br = mechanicalsoup.Browser()
@@ -43,14 +48,8 @@ class Account:
 
         # select competition to use
         competition_form = home_page.soup.select("form#ddlGamesJoinedForm")[0]
-        #print(competition_form)
-        #print(competition_form.select("select#edit-salutation"))
         [option.attrs.pop("selected", "") for option in competition_form.select("select#edit-salutation")[0]("option")]
-        #competition_form.select("select#edit-salutation")[0][competition_number] = True
-        #competition_form.select("select#edit-salutation")[0].find("option")[competition_number]["selected"] = True
-        #print(competition_form.select("select#edit-salutation")[0])
-        #print(competition_form.select("select#edit-salutation")[0].find("option"))
-        competition_form.select("select#edit-salutation")[0].find("option", {"value": str(competition_number)})["selected"] = True
+        competition_form.select("select#edit-salutation")[0].find_all("option")[competition_number]["selected"] = True
         br.submit(competition_form, home_page.url)
 
     def fetch(self, url):
@@ -247,7 +246,6 @@ class Account:
         elif price and priceType == "Stop":
             trade_form.select("input#stopPriceTextBox")[0]["value"] = str(price)
 
-        print(trade_form)
         prev_page = br.submit(trade_form, trade_page.url)
         prev_form = prev_page.soup.find("form", {"name": "simTradePreview"})
 

--- a/InvestopediaApi/ita.py
+++ b/InvestopediaApi/ita.py
@@ -25,7 +25,7 @@ class Duration(Enum):
 class Account:
     BASE_URL = 'http://www.investopedia.com'
 
-    def __init__(self, email, password):
+    def __init__(self, email, password,competition_number):
         """
         Logs a user into Investopedia's trading simulator,
         given a *username* and *password*.
@@ -39,7 +39,19 @@ class Account:
         login_form = login_page.soup.select("form#account-api-form")[0]
         login_form.select("#edit-email")[0]["value"] = email
         login_form.select("#edit-password")[0]["value"] = password
-        br.submit(login_form, login_page.url)
+        home_page = br.submit(login_form, login_page.url)
+
+        # select competition to use
+        competition_form = home_page.soup.select("form#ddlGamesJoinedForm")[0]
+        #print(competition_form)
+        #print(competition_form.select("select#edit-salutation"))
+        [option.attrs.pop("selected", "") for option in competition_form.select("select#edit-salutation")[0]("option")]
+        #competition_form.select("select#edit-salutation")[0][competition_number] = True
+        #competition_form.select("select#edit-salutation")[0].find("option")[competition_number]["selected"] = True
+        #print(competition_form.select("select#edit-salutation")[0])
+        #print(competition_form.select("select#edit-salutation")[0].find("option"))
+        competition_form.select("select#edit-salutation")[0].find("option", {"value": str(competition_number)})["selected"] = True
+        br.submit(competition_form, home_page.url)
 
     def fetch(self, url):
         url = '%s%s' % (self.BASE_URL, url)
@@ -235,9 +247,11 @@ class Account:
         elif price and priceType == "Stop":
             trade_form.select("input#stopPriceTextBox")[0]["value"] = str(price)
 
+        print(trade_form)
         prev_page = br.submit(trade_form, trade_page.url)
         prev_form = prev_page.soup.find("form", {"name": "simTradePreview"})
-        #br.submit(prev_form, prev_page.url)
+
+        br.submit(prev_form, prev_page.url)
 
         return True
 

--- a/InvestopediaApi/ita.py
+++ b/InvestopediaApi/ita.py
@@ -22,11 +22,6 @@ class Duration(Enum):
     day_order = 1
     good_cancel = 2
 
-class Option(Enum):
-    call = 1
-    put = 2
-
-
 class Account:
     BASE_URL = 'http://www.investopedia.com'
 
@@ -269,7 +264,7 @@ class Account:
 
         option_symbol = symbol+str(expire_date)[0:2]+str(expire_date)[4:6]+month_letter+str(strike_price)
 
-        # Investopedia requires all these Query Strings for the order form to be valid
+        # Investopedia requires these 3 Query Strings for the order form page to be valid
         option_page = '/simulator/trade/TradeOptions.aspx?sym='+option_symbol+'&s='+str(strike_price)+'&msym='+symbol
         br = self.br
         trade_page = self.fetch(option_page)
@@ -279,11 +274,6 @@ class Account:
         trade_form.select("input#txtNumContracts")[0]["value"] = str(quantity)
 
         # input transaction type
-        # class Action(Enum):
-        #     buy = 1
-        #     sell = 2
-        #     short = 3
-        #     cover = 4
         [option.attrs.pop("selected", "") for option in trade_form.select("select#ddlAction")[0]("option")]
         trade_form.select("select#ddlAction")[0].find("option", {"value": str(orderType.value)})["selected"] = True
 
@@ -301,7 +291,6 @@ class Account:
 
         elif price and priceType == "Stop":
             trade_form.select("input#stopPriceTextBox")[0]["value"] = str(price)
-
 
         prev_page = br.submit(trade_form, trade_page.url)
         prev_form = prev_page.soup.find("form", {"name": "simOptTradePreview"})


### PR DESCRIPTION
Not sure why GitHub thinks I changed the whole file. Probably in how I updated my fork with your repo. I only added the function trade_option

Examples:
client.trade_option("GOOG", Action.buy, "Call", 945, 170616, 1)
client.trade_option("GOOG", Action.buy, "Put", 932.50, 170616, 10, "Limit", 6.25)
client.trade_option(symbol, ordertype, optiontype, strikeprice, expire_date, quantity, pricetype, targetprice, duration)

Successfully tested option orders with limits, stops, Duration.day_order. Raises exception on error like with client.trade().

Date currently gets entered as YYMMDD (ex. "170616" for 2017-06-16). not sure if good idea.