### PR TITLE
Fixing get_quote

### DIFF
--- a/InvestopediaApi/ita.py
+++ b/InvestopediaApi/ita.py
@@ -325,6 +325,7 @@ def get_quote(symbol):
     parsed_html = response.soup
     try:
         quote = parsed_html.find('td', attrs={'id': quote_id}).text
+        quote = quote.replace(",", "")
     except:
         return False
     return float(quote)


### PR DESCRIPTION
I added a line in the `get_quote` function to replace commas in `quote` with an empty string. This avoids raising a ValueError that occurs if the argument is greater than 1,000 because it cannot be converted into a float