### PR TITLE
cast quantity in trade to an int

### DIFF
--- a/InvestopediaApi/ita.py
+++ b/InvestopediaApi/ita.py
@@ -219,6 +219,7 @@ class Account:
         client.trade("GOOG", Action.buy, 10)
         client.trade("GOOG", Action.buy, 10, "Limit", 500)
         """
+        quantity = int(quantity)
 
         br = self.br
         trade_page = self.fetch('/simulator/trade/tradestock.aspx')


### PR DESCRIPTION
Prevents less descriptive than the desired exception from being thrown than the input it not an int